### PR TITLE
Modified hash rate calculations

### DIFF
--- a/app/assets/javascripts/account-renderer.js
+++ b/app/assets/javascripts/account-renderer.js
@@ -4,6 +4,7 @@ import Vue from 'vue';
 
 var blockies = require('ethereum-blockies')
 var io = require('socket.io-client');
+var renderUtils = require('./render-utils')
 
 
 var app;
@@ -48,7 +49,7 @@ export default class AccountRenderer {
 
         var totalShares = 0;
 
-        data.map(item => item.minerData.hashRateFormatted = self.formatHashRate(item.minerData.hashRate   ))
+        data.map(item => item.minerData.hashRateFormatted = renderUtils.formatHashRate(item.minerData.hashRate   ))
         data.map(item => item.minerData.tokenBalanceFormatted = (item.minerData.tokenBalance / parseFloat(1e8)  ))
         data.map(item => item.minerData.tokenRewardsFormatted = (item.minerData.tokensAwarded / parseFloat(1e8)  ))
           data.map(item =>  (totalShares =  (totalShares + item.minerData.shareCredits) ) )
@@ -135,30 +136,6 @@ export default class AccountRenderer {
 
      htmlEntities(str) {
         return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-    }
-
-
-    formatHashRate(hashRate)
-    {
-      if(hashRate==null || hashRate==0)
-      {
-        return "--";
-      }
-
-      hashRate = parseFloat(hashRate);
-
-      if(hashRate > 10e9)
-      {
-        return (Math.round(hashRate / (10e9),2).toString() + "Gh/s");
-      }else if(hashRate > 10e6)
-      {
-        return (Math.round(hashRate / (10e6),2).toString() + "Mh/s");
-      }else if(hashRate > 10e3)
-      {
-        return (Math.round(hashRate / (10e3),2).toString() + "Kh/s");
-      }else{
-         return (Math.round(hashRate ,2).toString() + "H/s");
-      }
     }
 
 

--- a/app/assets/javascripts/profile-renderer.js
+++ b/app/assets/javascripts/profile-renderer.js
@@ -72,6 +72,7 @@ export default class ProfileRenderer {
      data.etherscanURL = ('https://etherscan.io/address/'+minerAddress.toString());
 
      data.tokenBalanceFormatted = self.formatTokenQuantity( data.tokenBalance );
+     data.hashRateFormatted = renderUtils.formatHashRate( data.hashRate );
 
      console.log('got miner details')
      console.dir(  data );

--- a/app/assets/javascripts/profile-renderer.js
+++ b/app/assets/javascripts/profile-renderer.js
@@ -3,6 +3,7 @@ import Vue from 'vue';
 var moment = require('moment');
 
 var io = require('socket.io-client');
+var renderUtils = require('./render-utils')
 
 
 var minerBalancePaymentsList;
@@ -114,7 +115,7 @@ export default class ProfileRenderer {
 
      data.map(item => item.timeFormatted = self.formatTime(item.time)     )
 
-     data.map(item => item.hashRateFormatted =  self.formatHashRate(item.hashRateEstimate)    )
+     data.map(item => item.hashRateFormatted =  renderUtils.formatHashRate(item.hashRateEstimate)    )
 
 
       Vue.set(minerSubmittedSharesList, 'shares',  {share_list: data.slice(0,50) }  )
@@ -222,31 +223,6 @@ export default class ProfileRenderer {
     }
 
     return moment.unix(time).format('MM/DD HH:mm');
-  }
-
-  formatHashRate(hashRate)
-  {
-
-    if(hashRate==null || hashRate==0)
-    {
-      return "--";
-    }
-
-
-    hashRate = parseFloat(hashRate);
-
-    if(hashRate > 10e9)
-    {
-      return (Math.round(hashRate / (10e9),2).toString() + "Gh/s");
-    }else if(hashRate > 10e6)
-    {
-      return (Math.round(hashRate / (10e6),2).toString() + "Mh/s");
-    }else if(hashRate > 10e3)
-    {
-      return (Math.round(hashRate / (10e3),2).toString() + "Kh/s");
-    }else{
-       return (Math.round(hashRate ,2).toString() + "H/s");
-    }
   }
 
   formatTokenQuantity(satoshis)

--- a/app/assets/javascripts/render-utils.js
+++ b/app/assets/javascripts/render-utils.js
@@ -7,9 +7,43 @@ module.exports={
 
   formatTokenQuantity(satoshis)
   {
-    return (parseFloat(satoshis) / parseFloat(1e8)).toString();
-  }
+	return (parseFloat(satoshis) / parseFloat(1e8)).toString();
+  },
 
+  // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
+  round(number, precision) {
+    var shift = function (number, precision, reverseShift) {
+      if (reverseShift) {
+        precision = -precision;
+      }  
+      numArray = ("" + number).split("e");
+      return +(numArray[0] + "e" + (numArray[1] ? (+numArray[1] + precision) : precision));
+    };
+    return shift(Math.round(shift(number, precision, false)), precision, true);
+  },
+
+  formatHashRate(hashRate)
+  {
+    if(hashRate==null || hashRate==0)
+    {
+      return "--";
+    }
+
+    hashRate = parseFloat(hashRate);
+
+    if(hashRate > 1e9)
+    {
+      return (this.round(hashRate / (1e9),2).toString() + " Gh/s");
+    }else if(hashRate > 1e6)
+    {
+      return (this.round(hashRate / (1e6),2).toString() + " Mh/s");
+    }else if(hashRate > 1e3)
+    {
+      return (this.round(hashRate / (1e3),2).toString() + " Kh/s");
+    }else{
+       return (this.round(hashRate ,2).toString() + " H/s");
+    }
+  }
 
 /*
   let url = new URL('http://www.test.com/t.html?a=1&b=3&c=m2-m3-m4-m5');

--- a/app/profile.html
+++ b/app/profile.html
@@ -49,7 +49,7 @@
        <tr> <td> Vardiff: {{  miner.minerData.varDiff }}  </td> </tr>
        <tr> <td> Using Custom Vardiff: {{  miner.minerData.usingCustomDifficulty }}  </td> </tr>
 
-       <tr> <td> Hashrate: {{  miner.minerData.hashRate }}  </td> </tr>
+       <tr> <td> Hashrate: {{  miner.minerData.hashRateFormatted }}  </td> </tr>
 
 
 

--- a/app/profile.html
+++ b/app/profile.html
@@ -66,7 +66,6 @@
             <tr >
               <td> EthBlock </td>
               <td> Time </td>
-              <td> Hashrate Est. </td>
               <td> Difficulty </td>
               <td> Nonce </td>
               <td> Is Full Solution </td>
@@ -80,7 +79,6 @@
 
               <td>    {{ item.block }} </td>
               <td>    {{ item.timeFormatted }} </td>
-              <td>    {{ item.hashRateFormatted }} </td>
               <td>    {{ item.difficulty }} </td>
               <td>    {{ item.nonce }} </td>
               <td>    {{ item.isSolution }} </td>

--- a/lib/peer-interface.js
+++ b/lib/peer-interface.js
@@ -1149,49 +1149,45 @@ module.exports =  {
 
           var validJSONSubmit = true;
 
-     var nonce = args[0];
-     var minerEthAddress = args[1];
-     var digest = args[2];
-     var difficulty = args[3];
-     var challenge_number = args[4]
+          var nonce = args[0];
+          var minerEthAddress = args[1];
+          var digest = args[2];
+          var difficulty = args[3];
+          var challenge_number = args[4]
 
-     //////////// start of MVI checks //////////////
-    if(
-        difficulty == null  ||
-        nonce == null  ||
-        minerEthAddress == null  ||
-        challenge_number == null  ||
-        digest == null
-      ) {
-          validJSONSubmit = false;
-      }
-
-
-    var poolEthAddress = self.getMintingAccount().address;
-    // this is fast isn't it?  It's just pulling data from redis? or am I wrong?
-    var poolChallengeNumber = await self.tokenInterface.getPoolChallengeNumber();
-    var computed_digest =  web3utils.soliditySha3( poolChallengeNumber , poolEthAddress, nonce )
-
-    var digestBigNumber = web3utils.toBN(digest);
-
-    if(computed_digest !== digest //||
-  //     digestBigNumber.gte(minShareTarget) ||
-  //   digestBigNumber.gte(claimedTarget)
-    ){
-      validJSONSubmit = false;
-    }
-     //////////// end of MVI checks //////////////
-
-     var ethBlock = await self.redisInterface.getEthBlockNumber();
-
-      var shareData = {block: ethBlock ,nonce: nonce,minerEthAddress: minerEthAddress,challengeNumber: challenge_number,digest: digest,difficulty: difficulty};
-
-      var response = await self.redisInterface.pushToRedisList("queued_shares_list", JSON.stringify(shareData));
+          if(
+            difficulty == null  ||
+            nonce == null  ||
+            minerEthAddress == null  ||
+            challenge_number == null  ||
+            digest == null
+          ) {
+            validJSONSubmit = false;
+          }
 
 
-      callback(null,  validJSONSubmit );
+          var poolEthAddress = self.getMintingAccount().address;
+          var poolChallengeNumber = await self.tokenInterface.getPoolChallengeNumber();
+          var computed_digest =  web3utils.soliditySha3( poolChallengeNumber , poolEthAddress, nonce )
 
-   },
+          var digestBigNumber = web3utils.toBN(digest);
+          var claimedTarget = self.getTargetFromDifficulty( difficulty )
+
+          if(computed_digest !== digest || digestBigNumber.gte(claimedTarget))
+          {
+            validJSONSubmit = false;
+          }
+
+          var ethBlock = await self.redisInterface.getEthBlockNumber();
+
+          var shareData = {block: ethBlock ,nonce: nonce,minerEthAddress: minerEthAddress,challengeNumber: challenge_number,digest: digest,difficulty: difficulty};
+
+          var response = await self.redisInterface.pushToRedisList("queued_shares_list", JSON.stringify(shareData));
+
+
+          callback(null,  validJSONSubmit );
+
+          },
 
 
 

--- a/lib/peer-interface.js
+++ b/lib/peer-interface.js
@@ -323,59 +323,61 @@ module.exports =  {
    //TimeToSolveBlock (seconds) = difficulty * 2^22 / hashrate (hashes per second)
 
 
-
+   //hashrate = (difficulty * 2^22) / timeToSolveABlock seconds)
    getEstimatedShareHashrate(difficulty, timeToFindSeconds )
    {
      if(timeToFindSeconds!= null && timeToFindSeconds>0)
      {
+
         var hashrate = web3utils.toBN(difficulty).mul( web3utils.toBN(2).pow(  web3utils.toBN(22) )).div( web3utils.toBN( timeToFindSeconds ) )
 
         return hashrate.toNumber(); //hashes per second
+
       }else{
         return 0;
       }
    },
 
-   //hashrate = (difficulty * 2^22) / timeToSolveABlock seconds)
    async estimateMinerHashrate(minerAddress)
    {
+      try {
 
-     var submitted_shares =  await this.redisInterface.getParsedElementsOfListInRedis(('miner_submitted_share:'+minerAddress.toString()), 20)
-
-     var sharesCount = 0;
-
-     if(submitted_shares == null || submitted_shares.length < 1)
-     {
-       return 0;
-     }
-
-
-     var summedHashrate = 0;
-
-     for (var i=0;i<submitted_shares.length;i++)
-     {
-       var share = submitted_shares[i];
-
-       var hashrate = parseInt(share.hashRateEstimate);
-
-       if(!isNaN(hashrate) && hashrate> 0 && hashrate != null)
-       {
-       summedHashrate += hashrate;
-       sharesCount++;
+        var submitted_shares =  await this.redisInterface.getParsedElementsOfListInRedis(('miner_submitted_share:'+minerAddress.toString()), 20);
+        
+        if(submitted_shares == null || submitted_shares.length < 1)
+        {
+          return 0;
         }
-     }
 
-     if(sharesCount <= 0)
-     {
-       return 0;
-     }
+        var totalDiff = 0;
+        var CUTOFF_MINUTES = 90;
+        var cutoff = peerUtils.getUnixTimeNow() - (CUTOFF_MINUTES * 60);
 
-     var hashrate = Math.floor(summedHashrate / sharesCount);
+        // the most recent share seems to be at the front of the list
+        var recentShareCount = 0;
+        while (recentShareCount < submitted_shares.length && submitted_shares[recentShareCount].time > cutoff) {
+          totalDiff += submitted_shares[recentShareCount].difficulty;
+          recentShareCount++;
+        }
 
+        if (isNaN(totalDiff) || recentShareCount == 0)
+        {
+          return 0;
+        }
 
+        var seconds = submitted_shares[0].time - submitted_shares[recentShareCount - 1].time;
+        if (seconds == 0) 
+        {
+          return 0;
+        }
+        var hashrate = this.getEstimatedShareHashrate( totalDiff, seconds );
+        return hashrate.toString();
 
-    return hashrate.toString()
-
+      } catch(err)
+      {
+        console.log('Error in peer-interface::estimateMinerHashrate: ',err);
+        return 0;
+      }
   },
 
 


### PR DESCRIPTION
I tried to break things into different commits ... I don't know if it makes it easier for you or  not

Summary of changes:
* there were a couple of bugs in `formatHashRate()`
   * expressions like 10e3, 10e6 & 10e9 should have been 1e3, 1e6 & 1e9
   * The Math.round function only takes 1 parameter, so I added a new round() function
* Changed the way hash rates were being estimated.  Instead of averaging the hash rate associated with each share, it now sums up the difficulty of each share, and calculates a hash rate based on that.
* Eliminated the hash rate column in the Submitted Share list on the Profile page.
* Formatted the hash rate value at the top of the Profile page